### PR TITLE
Made google_document_ai_processor_default_version test ignore changes to version field

### DIFF
--- a/.changelog/7317.txt
+++ b/.changelog/7317.txt
@@ -1,0 +1,3 @@
+```release-note:none
+
+```

--- a/google/resource_document_ai_processor_default_version.go
+++ b/google/resource_document_ai_processor_default_version.go
@@ -51,7 +51,8 @@ func resourceDocumentAIProcessorDefaultVersion() *schema.Resource {
 				Required:         true,
 				ForceNew:         true,
 				DiffSuppressFunc: projectNumberDiffSuppress,
-				Description:      `The version to set`,
+				Description: `The version to set. Using 'stable' or 'rc' will cause the API to return the latest version in that release channel.
+Apply 'lifecycle.ignore_changes' to the 'version' field to suppress this diff.`,
 			},
 		},
 		UseJSONNumber: true,

--- a/google/resource_document_ai_processor_default_version_generated_test.go
+++ b/google/resource_document_ai_processor_default_version_generated_test.go
@@ -54,7 +54,14 @@ resource "google_document_ai_processor" "processor" {
 
 resource "google_document_ai_processor_default_version" "processor" {
   processor = google_document_ai_processor.processor.id
-  version = "${google_document_ai_processor.processor.id}/processorVersions/pretrained-next"
+  version = "${google_document_ai_processor.processor.id}/processorVersions/stable"
+
+  lifecycle {
+    ignore_changes = [
+      # Using "stable" or "rc" will return a specific version from the API; suppressing the diff.
+      version,
+    ]
+  }
 }
 `, context)
 }

--- a/website/docs/r/document_ai_processor_default_version.html.markdown
+++ b/website/docs/r/document_ai_processor_default_version.html.markdown
@@ -40,7 +40,14 @@ resource "google_document_ai_processor" "processor" {
 
 resource "google_document_ai_processor_default_version" "processor" {
   processor = google_document_ai_processor.processor.id
-  version = "${google_document_ai_processor.processor.id}/processorVersions/pretrained-next"
+  version = "${google_document_ai_processor.processor.id}/processorVersions/stable"
+
+  lifecycle {
+    ignore_changes = [
+      # Using "stable" or "rc" will return a specific version from the API; suppressing the diff.
+      version,
+    ]
+  }
 }
 ```
 
@@ -51,7 +58,8 @@ The following arguments are supported:
 
 * `version` -
   (Required)
-  The version to set
+  The version to set. Using `stable` or `rc` will cause the API to return the latest version in that release channel.
+  Apply `lifecycle.ignore_changes` to the `version` field to suppress this diff.
 
 * `processor` -
   (Required)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Resolved https://github.com/hashicorp/terraform-provider-google/issues/12905 by altering the test to ignore changes (and improving documentation.)

`projectNumberDiffSuppress` is already in place to handle diffs based solely on the project id -> project number change; the larger issue is that the API replaces release channels (now called "stable" and "rc") with specific API versions. Unfortunately, this API does not supply a way to extract the list of versions in a particular release channel, so there's no way to make a data source to get the "latest stable version" and have the resource use that. Fully suppressing the diff in the provider would mislead users into thinking that they are on the latest stable or rc release, when in fact they might be extremely out of date.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```

Derived from https://github.com/GoogleCloudPlatform/magic-modules/pull/7317